### PR TITLE
use Humna's dithered OpSim columns in make_instcat

### DIFF
--- a/scripts/make_instcat
+++ b/scripts/make_instcat
@@ -4,6 +4,8 @@ Create instance catalogs via CatSim for each imsim_deep visit.
 """
 from __future__ import absolute_import, print_function
 import os
+import numpy as np
+import copy
 import sys
 import logging
 import warnings
@@ -36,6 +38,38 @@ visit_info = imsim_deep_utils.get_visit_info()
 obs_md = gen.getObservationMetaData(obsHistID=visit_info.obsHistId,
                                     boundLength=visit_info.instcat_radius)[0]
 
+# Apply dithering.  If any of the dithered summary table columns are missing,
+# emit a warning, so that the user knows.
+dithered_ra_name = 'randomDitherFieldPerVisitRA'
+dithered_dec_name = 'randomDitherFieldPerVisitDec'
+dithered_rot_tel_pos_name = 'ditheredRotTelPos'
+
+# dither RA
+try:
+    obs_md.pointingRA = np.degrees(obs_md.OpsimMetaData[dithered_ra_name])
+except KeyError:
+    warnings.warn('ObservationMetaData does not contain %s data' % dithered_ra_name)
+
+# dither Dec
+try:
+    obs_md.pointingDec = np.degrees(obs_md.OpsimMetaData[dithered_dec_name])
+except KeyError:
+    warnings.warn('ObservationMetaData does not contain %s data' % dithered_dec_name)
+
+# dither rotTelPos and rotSkyPos
+from lsst.sims.utils import _getRotSkyPos
+phosim_header_map = copy.deepcopy(DefaultPhoSimHeaderMap)
+try:
+    dithered_rot_tel = obs_md.OpsimMetaData[dithered_rot_tel_pos_name]
+    dithered_rot_sky = _getRotSkyPos(obs_md._pointingRA, obs_md._pointingDec,
+                                     obs_md, dithered_rot_tel)
+
+    obs_md.rotSkyPos = np.degrees(dithered_rot_sky)
+    phosim_header_map['rottelpos'] = (dithered_rot_tel_pos_name, np.degrees)
+except KeyError:
+    warnings.warn('ObservationMetaData does not contain %s data' % dithered_rot_tel_pos_name)
+
+
 star_objs = ['msstars', 'bhbstars', 'wdstars', 'rrlystars', 'cepheidstars']
 gal_objs = ['galaxyBulge', 'galaxyDisk']
 
@@ -45,7 +79,7 @@ for objid in star_objs:
     db_obj = CatalogDBObject.from_objid(objid, **db_config)
     phosim_object = PhoSimCatalogPoint(db_obj, obs_metadata=obs_md)
     if do_header:
-        phosim_object.phoSimHeaderMap = DefaultPhoSimHeaderMap
+        phosim_object.phoSimHeaderMap = phosim_header_map
         phosim_object.write_catalog(visit_info.instcat_file, write_mode='w',
                                     write_header=True, chunk_size=20000)
         do_header = False


### PR DESCRIPTION
This should include Humna's dithering columns.

Note: I had to make an executive decision about what the code should do if the dithering columns aren't present.  I chose to have the code emit a warning (since, maybe, sometime we will want to run this on an un-dithered database).  If you would rather have it fail in the absence of dithering, that can be done, too.